### PR TITLE
Fix GTest compilation

### DIFF
--- a/tests/test_ge_window.cpp
+++ b/tests/test_ge_window.cpp
@@ -4,6 +4,20 @@
 
 #include "gtest/gtest.h"
 
+namespace GE {
+
+void PrintTo(GE::KeyCode key_code, std::ostream* os)
+{
+    *os << key_code;
+}
+
+void PrintTo(GE::MouseButton button, std::ostream* os)
+{
+    *os << button;
+}
+
+} // namespace GE
+
 namespace {
 
 TEST(EventTest, Key)


### PR DESCRIPTION
For some reason, GTest couldn't find 'operator<<()' overload for a few types, it causes compile errors.