### PR TITLE
Allow threadpool work until query is empty

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks:             '*,
                     -hicpp-uppercase-literal-suffix,
                     -hicpp-use-auto,
                     -misc-non-private-member-variables-in-classes,
+                    -modernize-avoid-bind,
                     -modernize-use-nodiscard,
                     -modernize-use-trailing-return-type,
                     -readability-uppercase-literal-suffix'

--- a/include/ge/debug/profile.h
+++ b/include/ge/debug/profile.h
@@ -92,7 +92,7 @@ public:
         session = std::make_unique<session_t>();
         session->name = name;
         get()->writeHeader();
-        get()->m_thread_pool.start(_GE_PROFILER_THREAD_NUM);
+        get()->m_thread_pool.start(_GE_PROFILER_THREAD_NUM, true);
     }
 
     static void end() { get()->endSession(); }

--- a/include/ge/thread_pool.h
+++ b/include/ge/thread_pool.h
@@ -47,7 +47,7 @@ public:
     explicit ThreadPool(const char* name);
     ~ThreadPool();
 
-    void start(uint32_t threads_num);
+    void start(uint32_t threads_num, bool wait_for_query_end);
     void stop();
 
     template<typename Func, typename... Args>
@@ -58,7 +58,6 @@ public:
         }
 
         std::unique_lock lock{m_queue_mtx};
-        // NOLINTNEXTLINE
         m_queue.emplace(std::bind(std::forward<Func>(func), std::forward<Args>(args)...));
         lock.unlock();
         m_condition.notify_one();
@@ -70,6 +69,7 @@ private:
     void workerThread();
 
     std::atomic_bool m_terminated{true};
+    bool m_wait_for_query_end{false};
     std::condition_variable m_condition;
     std::vector<std::thread> m_workers;
     const char* m_name{nullptr};


### PR DESCRIPTION
We should allow threadpool working until the query is empty to write all profiling messages.